### PR TITLE
Adding support for multiple targets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
         "": {
             "name": "minerva",
             "version": "1.0.0",
-            "license": "MIT",
+            "license": "GPL-3.0",
             "dependencies": {
                 "@codemirror/basic-setup": "^0.19.1",
                 "@codemirror/collab": "^0.19.0",
@@ -20,6 +20,7 @@
                 "@octokit/core": "^3.6.0",
                 "axios": "^0.26.1",
                 "electron-oauth2": "^3.0.0",
+                "fountain-js": "^1.0.0",
                 "fs": "^0.0.1-security",
                 "highlight.js": "^11.5.1",
                 "jest": "^28.1.0",
@@ -7989,6 +7990,11 @@
             "engines": {
                 "node": ">= 0.12"
             }
+        },
+        "node_modules/fountain-js": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fountain-js/-/fountain-js-1.0.0.tgz",
+            "integrity": "sha512-WURsxp+ciH4zczdjNEGH06D8eVGlw3TDVyXiYZkeVJrQgmrrxlrKIm30TsPNgLELuFF9kYqZK+ft+ye1jcFgPQ=="
         },
         "node_modules/fraction.js": {
             "version": "4.2.0",
@@ -22092,6 +22098,11 @@
                 "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
             }
+        },
+        "fountain-js": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fountain-js/-/fountain-js-1.0.0.tgz",
+            "integrity": "sha512-WURsxp+ciH4zczdjNEGH06D8eVGlw3TDVyXiYZkeVJrQgmrrxlrKIm30TsPNgLELuFF9kYqZK+ft+ye1jcFgPQ=="
         },
         "fraction.js": {
             "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "@octokit/core": "^3.6.0",
         "axios": "^0.26.1",
         "electron-oauth2": "^3.0.0",
+        "fountain-js": "^1.0.0",
         "fs": "^0.0.1-security",
         "highlight.js": "^11.5.1",
         "jest": "^28.1.0",

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -18,6 +18,7 @@
 					:is="Component"
 					:gitService="gitService"
 					:loadedFile="loadedFile"
+					:target="target"
 					ref="view"
 					@login="login"
 					@logout="logout"
@@ -27,7 +28,11 @@
 			</keep-alive>
 		</transition>
 	</RouterView>
-	<Footer :gitService="gitService" :loadedFile="loadedFile" />
+	<Footer
+		:gitService="gitService"
+		:loadedFile="loadedFile"
+		:target="parserService?. || 'markdown'"
+	/>
 	<TemplatePickerModal
 		v-if="isModalOpen"
 		:isModalOpen="isModalOpen"
@@ -49,6 +54,7 @@ import type { GitRepo } from '@/typings/GitService';
 import TemplatePickerModal from './components/TemplatePickerModal.vue';
 import NotificationService from './services/notification.service';
 import NotificationLevel from './Interfaces/NotificationLevel';
+import MarkupParser from './services/parsers/markupParser';
 
 export default defineComponent({
 	components: {
@@ -62,18 +68,18 @@ export default defineComponent({
 	data(): {
 		roomId: string | null;
 		gitService: GithubClientService | null;
+		parserService: MarkupParser | null;
 		repo: GitRepo | null;
 		loadedFile: string | null;
 		isModalOpen: boolean;
-		target: string;
 	} {
 		return {
 			roomId: '',
 			gitService: null,
+			parserService: null,
 			repo: null,
 			loadedFile: null,
 			isModalOpen: false,
-			target: 'markdown',
 		};
 	},
 	created() {
@@ -81,6 +87,7 @@ export default defineComponent({
 	},
 	mounted() {
 		this.listeners();
+		this.
 	},
 
 	methods: {

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -79,7 +79,7 @@ export default defineComponent({
 		return {
 			roomId: '',
 			gitService: null,
-			parserService: new Fountain(),
+			parserService: new Markdown(),
 			repo: null,
 			loadedFile: null,
 			isModalOpen: false,

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -65,6 +65,7 @@ export default defineComponent({
 		repo: GitRepo | null;
 		loadedFile: string | null;
 		isModalOpen: boolean;
+		target: string;
 	} {
 		return {
 			roomId: '',
@@ -72,6 +73,7 @@ export default defineComponent({
 			repo: null,
 			loadedFile: null,
 			isModalOpen: false,
+			target: 'markdown',
 		};
 	},
 	created() {
@@ -269,6 +271,7 @@ export default defineComponent({
 
 <style>
 @import './css/github-markdown.css';
+@import './css/fountain.css';
 
 .fade-enter-from {
 	opacity: 0%;

--- a/src/renderer/src/components/Footer.vue
+++ b/src/renderer/src/components/Footer.vue
@@ -14,7 +14,8 @@
 			</div>
 		</div>
 		<select
-			:value="target"
+			@change="switchTarget"
+			:value="parserService.target"
 			class="h-full py-0 text-xs bg-transparent border-none"
 		>
 			<option value="markdown">markdown</option>
@@ -31,8 +32,15 @@ import FolderIcon from './svgs/FolderIcon.vue';
 export default defineComponent({
 	// take in props for file or repo connected... whether git is connected, etc
 	setup() {},
-	props: ['gitService', 'loadedFile', 'target'],
+	props: ['gitService', 'loadedFile', 'parserService'],
 	components: { GitIcon, FolderIcon },
-	methods: {},
+	methods: {
+		switchTarget(e: Event) {
+			this.$emit(
+				'changeTarget',
+				(e.currentTarget as HTMLInputElement).value,
+			);
+		},
+	},
 });
 </script>

--- a/src/renderer/src/components/Footer.vue
+++ b/src/renderer/src/components/Footer.vue
@@ -1,136 +1,38 @@
 <template>
 	<div
-		class="flex items-center px-4 absolute bottom-0 w-full h-5 bg-gray-200 text-gray-500 text-xs"
+		class="flex items-center justify-between px-4 absolute bottom-0 w-full h-5 bg-gray-200 text-gray-500 text-xs"
 	>
-		<div v-if="gitService && gitService.repo" class="flex">
-			{{ `@${gitService.repo?.ownerLogin}` }}
-			<svg
-				width="14"
-				height="14"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-				class="feather fether feather-git-branch mx-1"
-				version="1.1"
-				id="svg10"
-				sodipodi:docname="git.svg"
-				inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
-				xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-				xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-				xmlns="http://www.w3.org/2000/svg"
-				xmlns:svg="http://www.w3.org/2000/svg"
-			>
-				<defs id="defs14" />
-				<sodipodi:namedview
-					id="namedview12"
-					pagecolor="#ffffff"
-					bordercolor="#666666"
-					borderopacity="1.0"
-					inkscape:pageshadow="2"
-					inkscape:pageopacity="0.0"
-					inkscape:pagecheckerboard="0"
-					showgrid="false"
-					inkscape:zoom="34.958333"
-					inkscape:cx="11.985697"
-					inkscape:cy="12"
-					inkscape:window-width="1912"
-					inkscape:window-height="1040"
-					inkscape:window-x="4"
-					inkscape:window-y="323"
-					inkscape:window-maximized="0"
-					inkscape:current-layer="svg10"
-				/>
-				<line
-					x1="6"
-					y1="3"
-					x2="6"
-					y2="15"
-					id="line2"
-					style="stroke: #404040; stroke-opacity: 1"
-				/>
-				<circle
-					cx="18"
-					cy="6"
-					r="3"
-					id="circle4"
-					style="stroke: #404040; stroke-opacity: 1"
-				/>
-				<circle
-					cx="6"
-					cy="18"
-					r="3"
-					id="circle6"
-					style="stroke: #404040; stroke-opacity: 1"
-				/>
-				<path
-					d="M18 9a9 9 0 0 1-9 9"
-					id="path8"
-					style="stroke: #404040; stroke-opacity: 1"
-				/>
-			</svg>
-			{{ gitService.repo?.name }}
+		<div class="">
+			<div v-if="gitService && gitService.repo" class="flex">
+				{{ `@${gitService.repo?.ownerLogin}` }}
+				<GitIcon />
+				{{ gitService.repo?.name }}
+			</div>
+			<div v-else-if="loadedFile" class="flex items-center">
+				<FolderIcon />
+				{{ loadedFile }}
+			</div>
 		</div>
-		<div v-else-if="loadedFile" class="flex items-center">
-			<svg
-				width="14"
-				height="14"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-				class="feather feather-folder mr-1"
-				version="1.1"
-				id="svg4"
-				sodipodi:docname="folder.svg"
-				inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
-				xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-				xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-				xmlns="http://www.w3.org/2000/svg"
-				xmlns:svg="http://www.w3.org/2000/svg"
-			>
-				<defs id="defs8" />
-				<sodipodi:namedview
-					id="namedview6"
-					pagecolor="#ffffff"
-					bordercolor="#666666"
-					borderopacity="1.0"
-					inkscape:pageshadow="2"
-					inkscape:pageopacity="0.0"
-					inkscape:pagecheckerboard="0"
-					showgrid="false"
-					inkscape:zoom="34.958333"
-					inkscape:cx="11.985697"
-					inkscape:cy="12"
-					inkscape:window-width="1912"
-					inkscape:window-height="1040"
-					inkscape:window-x="4"
-					inkscape:window-y="323"
-					inkscape:window-maximized="0"
-					inkscape:current-layer="svg4"
-				/>
-				<path
-					d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"
-					id="path2"
-					style="stroke: #404040; stroke-opacity: 1"
-				/>
-			</svg>
-			{{ loadedFile }}
-		</div>
+		<select
+			:value="target"
+			class="h-full py-0 text-xs bg-transparent border-none"
+		>
+			<option value="markdown">markdown</option>
+			<option value="fountain">fountain</option>
+		</select>
 	</div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import GitIcon from './svgs/GitIcon.vue';
+import FolderIcon from './svgs/FolderIcon.vue';
 
 export default defineComponent({
 	// take in props for file or repo connected... whether git is connected, etc
 	setup() {},
-	props: ['gitService', 'loadedFile'],
+	props: ['gitService', 'loadedFile', 'target'],
+	components: { GitIcon, FolderIcon },
 	methods: {},
 });
 </script>

--- a/src/renderer/src/components/svgs/FolderIcon.vue
+++ b/src/renderer/src/components/svgs/FolderIcon.vue
@@ -1,0 +1,47 @@
+<template>
+	<svg
+		width="14"
+		height="14"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		class="feather feather-folder mr-1"
+		version="1.1"
+		id="svg4"
+		sodipodi:docname="folder.svg"
+		inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+		xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+		xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+		xmlns="http://www.w3.org/2000/svg"
+		xmlns:svg="http://www.w3.org/2000/svg"
+	>
+		<defs id="defs8" />
+		<sodipodi:namedview
+			id="namedview6"
+			pagecolor="#ffffff"
+			bordercolor="#666666"
+			borderopacity="1.0"
+			inkscape:pageshadow="2"
+			inkscape:pageopacity="0.0"
+			inkscape:pagecheckerboard="0"
+			showgrid="false"
+			inkscape:zoom="34.958333"
+			inkscape:cx="11.985697"
+			inkscape:cy="12"
+			inkscape:window-width="1912"
+			inkscape:window-height="1040"
+			inkscape:window-x="4"
+			inkscape:window-y="323"
+			inkscape:window-maximized="0"
+			inkscape:current-layer="svg4"
+		/>
+		<path
+			d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"
+			id="path2"
+			style="stroke: #404040; stroke-opacity: 1"
+		/>
+	</svg>
+</template>

--- a/src/renderer/src/components/svgs/GitIcon.vue
+++ b/src/renderer/src/components/svgs/GitIcon.vue
@@ -1,0 +1,69 @@
+<template>
+	<svg
+		width="14"
+		height="14"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		class="feather fether feather-git-branch mx-1"
+		version="1.1"
+		id="svg10"
+		sodipodi:docname="git.svg"
+		inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+		xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+		xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+		xmlns="http://www.w3.org/2000/svg"
+		xmlns:svg="http://www.w3.org/2000/svg"
+	>
+		<defs id="defs14" />
+		<sodipodi:namedview
+			id="namedview12"
+			pagecolor="#ffffff"
+			bordercolor="#666666"
+			borderopacity="1.0"
+			inkscape:pageshadow="2"
+			inkscape:pageopacity="0.0"
+			inkscape:pagecheckerboard="0"
+			showgrid="false"
+			inkscape:zoom="34.958333"
+			inkscape:cx="11.985697"
+			inkscape:cy="12"
+			inkscape:window-width="1912"
+			inkscape:window-height="1040"
+			inkscape:window-x="4"
+			inkscape:window-y="323"
+			inkscape:window-maximized="0"
+			inkscape:current-layer="svg10"
+		/>
+		<line
+			x1="6"
+			y1="3"
+			x2="6"
+			y2="15"
+			id="line2"
+			style="stroke: #404040; stroke-opacity: 1"
+		/>
+		<circle
+			cx="18"
+			cy="6"
+			r="3"
+			id="circle4"
+			style="stroke: #404040; stroke-opacity: 1"
+		/>
+		<circle
+			cx="6"
+			cy="18"
+			r="3"
+			id="circle6"
+			style="stroke: #404040; stroke-opacity: 1"
+		/>
+		<path
+			d="M18 9a9 9 0 0 1-9 9"
+			id="path8"
+			style="stroke: #404040; stroke-opacity: 1"
+		/>
+	</svg>
+</template>

--- a/src/renderer/src/css/fountain.css
+++ b/src/renderer/src/css/fountain.css
@@ -1,0 +1,52 @@
+.screenplay {
+	font-family: Courier, 'Courier New', monospace;
+	font-size: 12px;
+	max-width: 6in;
+	padding: 5px 14px 15px 14px !important;
+	margin: 0 auto 16px !important;
+}
+
+.screenplay p {
+	text-align: left !important;
+	letter-spacing: 0 !important;
+	margin-top: 0px !important;
+	margin-bottom: 0px !important;
+}
+
+.screenplay h3,
+.screenplay p,
+.screenplay h4 {
+	padding-top: 1em !important;
+}
+
+.screenplay h3 {
+	font-weight: bold;
+}
+
+.screenplay p {
+	padding-right: 5% !important;
+}
+
+.screenplay h4 {
+	padding-left: 40% !important;
+}
+
+.dialogue {
+	padding-left: 20% !important;
+	padding-right: 20% !important;
+}
+
+.parenthetical {
+	padding-left: 32% !important;
+	padding-right: 30% !important;
+}
+
+.dialogue + .parenthetical {
+	padding-bottom: 0 !important;
+}
+
+h2 {
+	padding-top: 3ex !important;
+	padding-left: 65% !important;
+	padding-bottom: 1.5ex !important;
+}

--- a/src/renderer/src/services/editor.service.ts
+++ b/src/renderer/src/services/editor.service.ts
@@ -134,7 +134,6 @@ export default class EditorService {
 						// eslint-disable-next-line no-param-reassign
 						vueComponent.parsedHTML =
 							Fountain.parse(documentString);
-						console.log(Fountain.parse(documentString));
 					}
 				},
 			}));

--- a/src/renderer/src/services/editor.service.ts
+++ b/src/renderer/src/services/editor.service.ts
@@ -19,6 +19,9 @@ import { marked } from 'marked';
 import { ChangeSet, StateField } from '@codemirror/state';
 
 import MARKED_SETTINGS from '../config/parsing';
+import type MarkupParser from './parsers/markupParser';
+import Markdown from './parsers/markdown';
+import Fountain from './parsers/fountain';
 
 export const MINERVA_LOCAL_SOCKET_SERVER_URL = 'http://localhost:8080/';
 export const MINERVA_SOCKET_SERVER_URL = 'https://text-sockets.herokuapp.com/';
@@ -35,6 +38,8 @@ export default class EditorService {
 	view: EditorView;
 
 	vueComponent: any;
+
+	parser: MarkupParser = Markdown;
 
 	constructor(
 		vueComponent: any,
@@ -93,13 +98,14 @@ export default class EditorService {
 		let plugin;
 		if (socket !== null) {
 			plugin = ViewPlugin.define(view => ({
-				update(editorUpdate) {
+				update: editorUpdate => {
 					if (editorUpdate.docChanged) {
 						// update parser
 						const doc = view.state.doc.toJSON();
 						const documentString = doc.join('\n');
 						// eslint-disable-next-line no-param-reassign
-						vueComponent.parsedHTML = marked.parse(documentString);
+						vueComponent.parsedHTML =
+							Fountain.parse(documentString);
 
 						// send updates to server
 						const unsentUpdates = sendableUpdates(view.state).map(
@@ -121,12 +127,14 @@ export default class EditorService {
 			}));
 		} else {
 			plugin = ViewPlugin.define(view => ({
-				update(editorUpdate) {
+				update: editorUpdate => {
 					if (editorUpdate.docChanged) {
 						const doc = view.state.doc.toJSON();
 						const documentString = doc.join('\n');
 						// eslint-disable-next-line no-param-reassign
-						vueComponent.parsedHTML = marked.parse(documentString);
+						vueComponent.parsedHTML =
+							Fountain.parse(documentString);
+						console.log(Fountain.parse(documentString));
 					}
 				},
 			}));

--- a/src/renderer/src/services/notification.service.ts
+++ b/src/renderer/src/services/notification.service.ts
@@ -4,7 +4,13 @@ export default class NotificationService {
 	constructor() {
 		window.ipcRenderer.on(
 			'notify',
-			(_: Electron.IpcRendererEvent, level: NotificationLevel, title: string, message: string, timeout = 5) => {
+			(
+				_: Electron.IpcRendererEvent,
+				level: NotificationLevel,
+				title: string,
+				message: string,
+				timeout = 5,
+			) => {
 				NotificationService.notify(level, title, message, timeout);
 			},
 		);

--- a/src/renderer/src/services/parsers/fountain.ts
+++ b/src/renderer/src/services/parsers/fountain.ts
@@ -1,0 +1,12 @@
+import { Fountain as Ftn } from 'fountain-js';
+import MarkupParser, { type Target } from './markupParser';
+
+export default class Fountain extends MarkupParser {
+	static target: Target = 'fountain';
+
+	static parse(content: string) {
+		const script = new Ftn().parse(content);
+		console.log(script);
+		return script.html.script;
+	}
+}

--- a/src/renderer/src/services/parsers/fountain.ts
+++ b/src/renderer/src/services/parsers/fountain.ts
@@ -6,7 +6,8 @@ export default class Fountain extends MarkupParser {
 
 	static parse(content: string) {
 		const script = new Ftn().parse(content);
-		console.log(script);
-		return script.html.script;
+		return script.html.script === '<p>undefined</p>'
+			? ''
+			: script.html.script;
 	}
 }

--- a/src/renderer/src/services/parsers/fountain.ts
+++ b/src/renderer/src/services/parsers/fountain.ts
@@ -1,10 +1,13 @@
 import { Fountain as Ftn } from 'fountain-js';
-import MarkupParser, { type Target } from './markupParser';
+import type { Target, MarkupParser } from './markupParser';
 
-export default class Fountain extends MarkupParser {
-	static target: Target = 'fountain';
+export default class Fountain implements MarkupParser {
+	target: Target = 'fountain';
 
-	static parse(content: string) {
+	className = 'screenplay';
+
+	// eslint-disable-next-line class-methods-use-this
+	parse(content: string) {
 		const script = new Ftn().parse(content);
 		return script.html.script === '<p>undefined</p>'
 			? ''

--- a/src/renderer/src/services/parsers/markdown.ts
+++ b/src/renderer/src/services/parsers/markdown.ts
@@ -1,0 +1,13 @@
+import { marked } from 'marked';
+import type { Target } from './markupParser';
+import MarkupParser from './markupParser';
+
+export default class Markdown extends MarkupParser {
+	static target: Target = 'markdown';
+
+	static cssPath = './css/index.css';
+
+	static parse(content: string) {
+		return marked.parse(content);
+	}
+}

--- a/src/renderer/src/services/parsers/markdown.ts
+++ b/src/renderer/src/services/parsers/markdown.ts
@@ -1,13 +1,15 @@
 import { marked } from 'marked';
-import type { Target } from './markupParser';
-import MarkupParser from './markupParser';
+import MARKED_SETTINGS from '../../config/parsing';
+import type { Target, MarkupParser } from './markupParser';
 
-export default class Markdown extends MarkupParser {
-	static target: Target = 'markdown';
+export default class Markdown implements MarkupParser {
+	target: Target = 'markdown';
 
-	static cssPath = './css/index.css';
+	className = 'markdown-body';
 
-	static parse(content: string) {
+	// eslint-disable-next-line class-methods-use-this
+	parse(content: string) {
+		marked.setOptions(MARKED_SETTINGS);
 		return marked.parse(content);
 	}
 }

--- a/src/renderer/src/services/parsers/markupParser.ts
+++ b/src/renderer/src/services/parsers/markupParser.ts
@@ -1,12 +1,12 @@
 export type Target = 'markdown' | 'fountain';
 
 // this will be a bigger part of a global config that uses dependency injection
-export default abstract class MarkupParser {
-	static target: Target;
+export interface MarkupParser {
+	target: Target;
 
 	/** Path to css required for preview */
-	static cssPath?: string;
+	className?: string;
 
 	/** Function that takes in raw markup and produces formatted text */
-	static parse: (content: string) => string;
+	parse: (content: string) => string;
 }

--- a/src/renderer/src/services/parsers/markupParser.ts
+++ b/src/renderer/src/services/parsers/markupParser.ts
@@ -1,0 +1,12 @@
+export type Target = 'markdown' | 'fountain';
+
+// this will be a bigger part of a global config that uses dependency injection
+export default abstract class MarkupParser {
+	static target: Target;
+
+	/** Path to css required for preview */
+	static cssPath?: string;
+
+	/** Function that takes in raw markup and produces formatted text */
+	static parse: (content: string) => string;
+}

--- a/src/renderer/src/views/Editor.vue
+++ b/src/renderer/src/views/Editor.vue
@@ -10,7 +10,7 @@
 		<pane size="50" min-size="20" max-size="75">
 			<div class="overflow-auto">
 				<article
-					class="markdown-body editor-height p-3"
+					class="screenplay editor-height p-3"
 					id="parsed-html"
 					v-html="parsedHTML"
 				></article>
@@ -169,4 +169,5 @@ export default defineComponent({
 
 <style>
 @import '../css/github-markdown.css';
+@import '../css/fountain.css';
 </style>

--- a/src/renderer/src/views/Editor.vue
+++ b/src/renderer/src/views/Editor.vue
@@ -10,7 +10,8 @@
 		<pane size="50" min-size="20" max-size="75">
 			<div class="overflow-auto">
 				<article
-					class="screenplay editor-height p-3"
+					class="editor-height p-3"
+					:class="parserService.className"
 					id="parsed-html"
 					v-html="parsedHTML"
 				></article>
@@ -31,9 +32,11 @@ import NotificationService from '../services/notification.service';
 
 import { Splitpanes, Pane } from 'splitpanes';
 import 'splitpanes/dist/splitpanes.css';
+import type { MarkupParser } from '../services/parsers/markupParser';
+import Markdown from '../services/parsers/markdown';
 
 export default defineComponent({
-	props: ['gitService', 'loadedFile'],
+	props: ['gitService', 'loadedFile', 'parserService'],
 	data(): {
 		editorService: EditorService | null;
 		view: EditorView | null;
@@ -55,14 +58,24 @@ export default defineComponent({
 	},
 
 	mounted() {
-		this.view = this.newEditorService();
+		this.view = this.newEditorService(this.parserService);
+	},
+
+	watch: {
+		parserService: function () {
+			this.newEditorFromString(this.getEditorContent() || '');
+		},
 	},
 
 	methods: {
 		async createCollabSession() {
 			const docJSON = this.view?.state.doc.toJSON();
 			this.view?.destroy();
-			this.view = this.newEditorService(true, docJSON?.join('\n'));
+			this.view = this.newEditorService(
+				this.parserService,
+				true,
+				docJSON?.join('\n'),
+			);
 			this.roomId = EditorService.generateRoomId();
 			this.editorService?.socketsCreateNewRoom(this.roomId);
 			NotificationService.notify(
@@ -77,7 +90,7 @@ export default defineComponent({
 		async joinCollabSession(roomId: string) {
 			this.roomId = roomId;
 			this.view?.destroy();
-			this.view = this.newEditorService(true);
+			this.view = this.newEditorService(undefined, true);
 			this.editorService?.socketsJoinRoom(this.roomId);
 			NotificationService.notify(
 				NotificationLevel.Success,
@@ -89,7 +102,11 @@ export default defineComponent({
 
 		newEditorFromString(fileContents: string) {
 			if (this.view) this.view.destroy();
-			this.view = this.newEditorService(false, fileContents);
+			this.view = this.newEditorService(
+				this.parserService,
+				false,
+				fileContents,
+			);
 		},
 
 		newBlankEditor() {
@@ -97,7 +114,7 @@ export default defineComponent({
 			if (this.editorService?.socket)
 				this.editorService.disconnectSocket();
 			this.view?.destroy();
-			this.view = this.newEditorService();
+			this.view = this.newEditorService(this.parserService);
 		},
 
 		async commitChanges() {
@@ -134,6 +151,7 @@ export default defineComponent({
 		},
 
 		newEditorService(
+			parserService: MarkupParser = new Markdown(),
 			socket = false,
 			startDoc: string = '',
 			startUpdates: Update[] = [],
@@ -144,6 +162,7 @@ export default defineComponent({
 
 			const doc = startDoc.split('\n');
 			this.editorService = new EditorService(
+				parserService,
 				this,
 				{
 					doc: doc,


### PR DESCRIPTION
This PR adds the infrastructure necessary to extend the parser to support markup languages beyond just markdown. Used as an example is the [fountain screenplay markup format](https://fountain.io/). 

- Dropdown in status bar to select target
- dynamically sets stylesheet and markup parser
- future work will include automatically reading a file extension and setting the appropriate `parserService`

[Screencast from 02-10-2023 01:30:50 AM.webm](https://user-images.githubusercontent.com/71541064/218057768-1cf3f07e-a1b0-4c18-b930-c2a831d87eff.webm)
